### PR TITLE
Lower "EvasiveToHitFloor" for "panicked" shots

### DIFF
--- a/StreamingAssets/data/behaviorVariables/role_lastmanstanding.json
+++ b/StreamingAssets/data/behaviorVariables/role_lastmanstanding.json
@@ -134,6 +134,13 @@
       }
     },
     {
+      "k": "Float_EvasiveToHitFloor",
+      "v": {
+        "type": "Float",
+        "floatVal": 30.0
+      }
+    },
+    {
       "k": "Float_PreferLOSToMostHostilesFactorWeight",
       "v": {
         "type": "Float",


### PR DESCRIPTION
In addition to the lowered overheat threshold, LastManStanding will now blast poor targets if it's the only one available instead of firing a single conservative shot.