### PR TITLE
Daily test branch

### DIFF
--- a/StreamingAssets/data/behaviorVariables/global.json
+++ b/StreamingAssets/data/behaviorVariables/global.json
@@ -438,7 +438,7 @@
       "k": "Float_MeleeBonusMultiplierWhenAttackingBracedTargets",
       "v": {
         "type": "Float",
-        "floatVal": 2.5
+        "floatVal": 3.0
       }
     },
     {

--- a/StreamingAssets/data/behaviorVariables/global.json
+++ b/StreamingAssets/data/behaviorVariables/global.json
@@ -214,7 +214,7 @@
       "k": "Float_MeleeDamageMultiplier",
       "v": {
         "type": "Float",
-        "floatVal": 2.75
+        "floatVal": 3.0
       }
     },
     {
@@ -634,14 +634,14 @@
       "k": "Float_PreferLethalDamageToRearArcFromHostileFactorWeight",
       "v": {
         "type": "Float",
-        "floatVal": -1.5
+        "floatVal": -1.75
       }
     },
     {
       "k": "Float_SprintPreferLethalDamageToRearArcFromHostileFactorWeight",
       "v": {
         "type": "Float",
-        "floatVal": -1.5
+        "floatVal": -2.0
       }
     },
     {
@@ -837,7 +837,7 @@
       "k": "Float_CenterTorsoRearArmorMultiplier",
       "v": {
         "type": "Float",
-        "floatVal": 15
+        "floatVal": 10
       }
     },
     {
@@ -858,14 +858,14 @@
       "k": "Float_OpportunityFireExceedsDesignatedTargetByPercentage",
       "v": {
         "type": "Float",
-        "floatVal": 30.0
+        "floatVal": 25.0
       }
     },
     {
       "k": "Float_OpportunityFireExceedsDesignatedTargetFirepowerTakeawayByPercentage",
       "v": {
         "type": "Float",
-        "floatVal": 30.0
+        "floatVal": 25.0
       }
     },
     {
@@ -956,7 +956,7 @@
       "k": "Float_AlonePreferenceWeight",
       "v": {
         "type": "Float",
-        "floatVal": -0.8
+        "floatVal": -1.2
       }
     },
     {

--- a/StreamingAssets/data/behaviorVariables/global.json
+++ b/StreamingAssets/data/behaviorVariables/global.json
@@ -214,7 +214,7 @@
       "k": "Float_MeleeDamageMultiplier",
       "v": {
         "type": "Float",
-        "floatVal": 2.5
+        "floatVal": 2.75
       }
     },
     {
@@ -466,7 +466,7 @@
       "k": "Float_BulwarkThresholdPercentage",
       "v": {
         "type": "Float",
-        "floatVal": 75
+        "floatVal": 80
       }
     },
     {

--- a/StreamingAssets/data/behaviorVariables/global_def.json
+++ b/StreamingAssets/data/behaviorVariables/global_def.json
@@ -305,7 +305,7 @@
       "k": "Float_OverkillFactorForReserve",
       "v": {
         "type": "Float",
-        "floatVal": 90.0
+        "floatVal": 80.0
       }
     },
     {

--- a/StreamingAssets/data/behaviorVariables/global_def.json
+++ b/StreamingAssets/data/behaviorVariables/global_def.json
@@ -186,7 +186,7 @@
       "k": "Float_MeleeDamageMultiplier",
       "v": {
         "type": "Float",
-        "floatVal": 2.5
+        "floatVal": 3.0
       }
     },
     {

--- a/StreamingAssets/data/behaviorVariables/role_lastmanstanding.json
+++ b/StreamingAssets/data/behaviorVariables/role_lastmanstanding.json
@@ -60,7 +60,7 @@
       "k": "Float_MeleeDamageMultiplier",
       "v": {
         "type": "Float",
-        "floatVal": 3.0
+        "floatVal": 3.5
       }
     },
     {

--- a/StreamingAssets/data/behaviorVariables/role_scout.json
+++ b/StreamingAssets/data/behaviorVariables/role_scout.json
@@ -109,7 +109,7 @@
       "k": "Float_PreferInsideMeleeRangeFactorWeight",
       "v": {
         "type": "Float",
-        "floatVal": -0.8
+        "floatVal": -1.0
       }
     },
     {
@@ -138,6 +138,13 @@
       "v": {
         "type": "Float",
         "floatVal": 1.0
+      }
+    },
+    {
+      "k": "Float_BulwarkThresholdPercentage",
+      "v": {
+        "type": "Float",
+        "floatVal": 30
       }
     },
     {
@@ -179,7 +186,7 @@
       "k": "Float_OverkillFactorForReserve",
       "v": {
         "type": "Float",
-        "floatVal": 100.0
+        "floatVal": 80.0
       }
     },
     {
@@ -228,7 +235,7 @@
       "k": "Float_SprintHysteresisRecoveryTurns",
       "v": {
         "type": "Float",
-        "floatVal": 0.0
+        "floatVal": 1.0
       }
     },
     {
@@ -249,7 +256,7 @@
       "k": "Float_FenceRadius",
       "v": {
         "type": "Float",
-        "floatVal": 200.0
+        "floatVal": 192.0
       }
     },
     {
@@ -263,7 +270,7 @@
       "k": "Bool_UseBulwarkActions",
       "v": {
         "type": "Bool",
-        "boolVal": false
+        "boolVal": true
       }
     },
     {

--- a/StreamingAssets/data/behaviorVariables/role_scout.json
+++ b/StreamingAssets/data/behaviorVariables/role_scout.json
@@ -137,7 +137,7 @@
       "k": "Float_MeleeBonusMultiplierWhenAttackingBracedTargets",
       "v": {
         "type": "Float",
-        "floatVal": 0.0
+        "floatVal": 1.0
       }
     },
     {

--- a/StreamingAssets/data/behaviorVariables/role_sniper.json
+++ b/StreamingAssets/data/behaviorVariables/role_sniper.json
@@ -123,7 +123,7 @@
       "k": "Float_FenceRadius",
       "v": {
         "type": "Float",
-        "floatVal": 200
+        "floatVal": 192
       }
     },
     {

--- a/mod.json
+++ b/mod.json
@@ -2,7 +2,7 @@
     "Name": "Better AI",
     "Enabled": true,
 
-    "Version": "1.0.0",
+    "Version": "1.2.0",
     "Description": "Changes AI Behavior Variables for a better AI experience",
     "Author": "amechwarrior",
     "Website": "https://github.com/Mpstark/BetterAI/"


### PR DESCRIPTION
Float_FenceRadius adjusted to increments of 24 to match dot pitch across all files
Global -
Increased protecting rear arc from -1.5 to -1.75 and -1.5 to -2.0 sprint, slightly less chance of moving where rear is exposed
Lowered point multiplier for rear armor counting from 15 to 10, more rear seeking attack weight
Increased melee multipliers from 2.5 to 3 for normal and braced targets
Bulwark % increased from 75% to 80%
Lowered opportunity fire chance from 30% to 25% (20% stock) to let AI take more opportunity shots on vulnerable, but not primary targets
Increased need to not be alone from -0.8 to -1.2 for slightly better chance lone unit will fall back and regroup with Lance
Defensive Mood - 
Lowered overkill threshold for reserve from 90 to 80, defensive units less likely to reserve if expecting heavy fire
Increased Melee Damage Multi from 2.5 to 3.0
Last Man Standing - 
Increased Melee Damage Multi from 3.0 to 3.5
Scout -
Bulwark allowed, if rarely, set to 30%
Increased fear of melee range from -0.8 to -1.0
Enabled Melee Bonus Multiplier when attacking Braced targets, from 0.0 to 1.0, overall Scouts should still not want to melee, but can break Brace a little more frequently
Lowered overkill threshold for reserve from 100 to 80, Scouts less likely to reserve if expecting heavy fire
Set sprint hysteresis recovery from 0.0 to 1.0 (2.0 stock) to allow on/off sprint and deny endless sprinting
Vehicles
